### PR TITLE
Pin all version dependencies to major and minor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Install "twine" as a dev dependency.
 - Add an option to "setup.py upload" to use the test index by default.
+- Pin package dependency major and minor versions.
 
 ## [0.0.0] - 2018-09-09
 ### Added

--- a/Pipfile
+++ b/Pipfile
@@ -4,9 +4,14 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-tox = "*"
-pylint = "*"
-twine = "*"
+# This list should stay in sync with the test dependencies in setup.py.  This is
+# necessary because those dependencies are only installed with the "[testing]"
+# group.  See tox.ini for details.
+pytest = '>=3.8.0,<3.9.0',
+pytest-xdist = '>=1.23.0,<1.24.0',
+tox = '>=3.2.1,<3.3.0',
+pylint = '>=2.1.1,<2.2.0'
+twine = '>=1.11.0,<1.12.0'
 
 [packages]
 "e1839a8" = {path = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3ab59af2fc934a5a046df1cbc1f1dfff0ef344bed58ad31f7656fd4c62e817c9"
+            "sha256": "b39e1ed73bc7955d81bd4161155ace326571c572c57a7a70ae814196e2dab672"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -68,10 +68,10 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:7fdc2f6f21372572fec9df52e70b5ae11c263fe5905fc61dbd7ac3b01350cb4a",
-                "sha256:e3ac48844b5ee6adafd27f6682efdd009a9c5f70abef0b72092d039ae3050279"
+                "sha256:0ed4b107c3b4550547aaec3c9bb17df068ff92d1f6f4781205800e2cb8a66de5",
+                "sha256:64496f2c814e454e26c024df86bd08fb4643770d0e2b7a8fd70055fc6683eb9d"
             ],
-            "version": "==1.7.77"
+            "version": "==1.7.84"
         },
         "botocore": {
             "hashes": [
@@ -265,10 +265,10 @@
         },
         "moto": {
             "hashes": [
-                "sha256:7c86d1c3bd6362954afaded735354c11afd22037eb6736152f057a1bff0c8868",
-                "sha256:b8556c1e0cebf931a698bf7198bb3eaf2287c8c9bb4f3455ea5d2015ad8f1708"
+                "sha256:52426f2567e51ba73fdc7c7d617236b7e7918dca2421caabe13e5290942b53d8",
+                "sha256:c4c6f7ae1f6ce6ccce790adcc806db2f3127424da310dbe7f682ec4a0fa80df3"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "pbr": {
             "hashes": [
@@ -451,12 +451,35 @@
         }
     },
     "develop": {
+        "apipkg": {
+            "hashes": [
+                "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
+                "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*'",
+            "version": "==1.5"
+        },
         "astroid": {
             "hashes": [
                 "sha256:292fa429e69d60e4161e7612cb7cc8fa3609e2e309f80c224d93a76d5e7b58be",
                 "sha256:c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d"
             ],
             "version": "==2.0.4"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*'",
+            "version": "==1.2.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
         },
         "certifi": {
             "hashes": [
@@ -471,6 +494,14 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "execnet": {
+            "hashes": [
+                "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
+                "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*'",
+            "version": "==1.5.0"
         },
         "idna": {
             "hashes": [
@@ -529,6 +560,14 @@
             ],
             "version": "==0.6.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "version": "==4.3.0"
+        },
         "pkginfo": {
             "hashes": [
                 "sha256:5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474",
@@ -559,6 +598,28 @@
             ],
             "index": "pypi",
             "version": "==2.1.1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:453cbbbe5ce6db38717d282b758b917de84802af4288910c12442984bde7b823",
+                "sha256:a8a07f84e680482eb51e244370aaf2caa6301ef265f37c2bdefb3dd3b663f99d"
+            ],
+            "version": "==3.8.0"
+        },
+        "pytest-forked": {
+            "hashes": [
+                "sha256:e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805",
+                "sha256:f275cb48a73fc61a6710726348e1da6d68a978f0ec0c54ece5a5fae5977e5a08"
+            ],
+            "version": "==0.2"
+        },
+        "pytest-xdist": {
+            "hashes": [
+                "sha256:0875deac20f6d96597036bdf63970887a6f36d28289c2f6682faf652dfea687b",
+                "sha256:28e25e79698b2662b648319d3971c0f9ae0e6500f88258ccb9b153c31110ba9b"
+            ],
+            "index": "pypi",
+            "version": "==1.23.0"
         },
         "requests": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -19,13 +19,8 @@ and run:
 
 ```shell
 cd cloudless_experimentation
-pipenv install botocore==1.10.84
 pipenv install cloudless
 ```
-
-You need to explicitly install that version of botocore right now because of
-https://github.com/getcloudless/cloudless/issues/4, but that is actually a bug
-in version 0.0.0 of cloudless.
 
 Having a dedicated directory will allow pipenv to scope the dependencies to that
 project directory and prevent this project from installing stuff on your main

--- a/setup.py
+++ b/setup.py
@@ -22,26 +22,27 @@ NAME = 'cloudless'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'boto3==1.7.77',
-    'PyYaml',
-    'jinja2',
+    'boto3>=1.7.77,<1.8.0',
+    'botocore>=1.10.84,<1.11.0',
+    'PyYaml>=3.13,<4.0',
+    'jinja2>=2.10,<3.0',
     # This pytest dependency is only for the module tester.  Perhaps this should
     # be a separate module eventually.
-    'pytest',
-    'attr',
-    'click',
-    'apache-libcloud',
-    'pycryptodome',
+    'pytest>=3.8.0,<3.9.0',
+    'attr>=0.3.1,<0.4.0',
+    'click>=6.7,<7.0',
+    'apache-libcloud>=2.3.0,<2.4.0',
+    'pycryptodome>=3.6.6,<3.7.0',
     # Even though moto is for testing, need it for the "mock-aws" provider.
-    'moto==1.3.4',
+    'moto>=1.3.5,<1.4.0',
 ]
 
 # What packages are required for this module to be tested?
 TESTS_REQUIRED = [
-    'pytest',
-    'pytest-xdist',
-    'tox',
-    'pylint'
+    'pytest>=3.8.0,<3.9.0',
+    'pytest-xdist>=1.23.0,<1.24.0',
+    'tox>=3.2.1,<3.3.0',
+    'pylint>=2.1.1,<2.2.0'
 ]
 
 # What packages are optional?
@@ -92,7 +93,7 @@ class UploadCommand(Command):
         """
         Unused/noop
         """
-        # pylint:disable=use-test-index
+        # pylint:disable=attribute-defined-outside-init
         self.use_test_index = "true"
 
     def finalize_options(self):
@@ -118,13 +119,14 @@ class UploadCommand(Command):
         self.status('Uploading the package to PyPI via Twine…')
         if self.use_test_index == "false":
             os.system('twine upload dist/*')
+
+            # Only push git tags when uploading to real pypi
+            self.status('Pushing git tags…')
+            os.system('git tag v{0}'.format(about['__version__']))
+            os.system('git push --tags')
         else:
             self.status('Using test index.  Run with "--use-test-index false" to use real pypi.')
             os.system('twine upload --repository-url https://test.pypi.org/legacy/ dist/*')
-
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(about['__version__']))
-        os.system('git push --tags')
 
         sys.exit()
 


### PR DESCRIPTION
Let patch versions change for now in case of security fixes.

Fixes: https://github.com/getcloudless/cloudless/issues/4