### PR TITLE
Make sure to only print paths that match network

### DIFF
--- a/cloudless/cli/service.py
+++ b/cloudless/cli/service.py
@@ -84,6 +84,8 @@ def add_service_group(cldls):
             has_access_to = ["default-all-outgoing-allowed"]
             is_accessible_from = []
             for path in paths:
+                if path.network.name != service.network.name:
+                    continue
                 if path.destination.name == service.name:
                     if path.source.name:
                         is_accessible_from.append("%s:%s:%s" % (path.network.name, path.source.name,


### PR DESCRIPTION
The service get was printing multiple paths if our service name happened
to be the same as a service in another network.