### PR TITLE
Fix twice deletion when service references itself

### DIFF
--- a/cloudless/providers/gce/impl/firewalls.py
+++ b/cloudless/providers/gce/impl/firewalls.py
@@ -29,7 +29,9 @@ class Firewalls:
                 if tag in firewall.source_tags:
                     logger.info("Deleting firewall %s because of source tag: %s", firewall, tag)
                     self.driver.ex_destroy_firewall(firewall)
+                    continue
             if firewall.target_tags:
                 if tag in firewall.target_tags:
                     logger.info("Deleting firewall %s because of target tag: %s", firewall, tag)
                     self.driver.ex_destroy_firewall(firewall)
+                    continue


### PR DESCRIPTION
This was an issue when a service had a rule that allowed instances of that service to talk to each other.  The deletion would fire twice and cause the command to fail and get in a bad state.