### PR TITLE
Put temporary state in a .cloudless directory

### DIFF
--- a/cloudless/testutils/blueprint_tester.py
+++ b/cloudless/testutils/blueprint_tester.py
@@ -60,7 +60,9 @@ def save_state(state, config):
     """
     Save test state so we can run each command independently.
     """
-    state_file_path = "%s/%s" % (config.get_config_dir(), TEST_STATE_FILENAME)
+    if not os.path.exists(config.get_state_dir()):
+        os.mkdir(config.get_state_dir())
+    state_file_path = "%s/%s" % (config.get_state_dir(), TEST_STATE_FILENAME)
     state_json = json.dumps(state, indent=2, sort_keys=True)
     with open(state_file_path, "w") as state_file:
         state_file.write(state_json)
@@ -69,13 +71,13 @@ def private_key_path(config):
     """
     Path where this framework saves the private test key.
     """
-    return "%s/%s" % (config.get_config_dir(), "id_rsa_test")
+    return "%s/%s" % (config.get_state_dir(), "id_rsa_test")
 
 def public_key_path(config):
     """
     Path where this framework saves the public test key.
     """
-    return "%s/%s" % (config.get_config_dir(), "id_rsa_test.pub")
+    return "%s/%s" % (config.get_state_dir(), "id_rsa_test.pub")
 
 def save_key_pair(key_pair, config):
     """
@@ -98,7 +100,7 @@ def get_state(config):
     """
     Get test state so we can run each command independently.
     """
-    state_file_path = "%s/%s" % (config.get_config_dir(), TEST_STATE_FILENAME)
+    state_file_path = "%s/%s" % (config.get_state_dir(), TEST_STATE_FILENAME)
     if not os.path.exists(state_file_path):
         return {}
     with open(state_file_path, "r") as state_file:

--- a/cloudless/util/blueprint_test_configuration.py
+++ b/cloudless/util/blueprint_test_configuration.py
@@ -32,7 +32,13 @@ class BlueprintTestConfiguration:
         """
         Get directory of the file behind this configuration.
         """
-        return self.config_path
+        return os.path.abspath(self.config_path)
+
+    def get_state_dir(self):
+        """
+        Get temporary state directory for this configuration.
+        """
+        return os.path.join(self.get_config_dir(), ".cloudless")
 
     def get_count(self):
         """

--- a/cloudless/util/image_build_configuration.py
+++ b/cloudless/util/image_build_configuration.py
@@ -38,7 +38,13 @@ class ImageBuildConfiguration:
         """
         Get directory of the file behind this configuration.
         """
-        return self.config_path
+        return os.path.abspath(self.config_path)
+
+    def get_state_dir(self):
+        """
+        Get temporary state directory for this configuration.
+        """
+        return os.path.join(self.get_config_dir(), ".cloudless")
 
     def get_blueprint_path(self):
         """

--- a/examples/apache/.gitignore
+++ b/examples/apache/.gitignore
@@ -1,4 +1,2 @@
-blueprint-test-state.json
 Pipfile.lock
-id_rsa_test
-id_rsa_test.pub
+.cloudless

--- a/examples/base-image/.gitignore
+++ b/examples/base-image/.gitignore
@@ -1,3 +1,2 @@
-cloudless-image-build-state.json
-id_rsa_image_build
-id_rsa_image_build.pub
+Pipfile.lock
+.cloudless

--- a/examples/haproxy/.gitignore
+++ b/examples/haproxy/.gitignore
@@ -1,4 +1,2 @@
-blueprint-test-state.json
 Pipfile.lock
-id_rsa_test
-id_rsa_test.pub
+.cloudless

--- a/tests/blueprint_tester_fixture/.gitignore
+++ b/tests/blueprint_tester_fixture/.gitignore
@@ -1,2 +1,1 @@
-blueprint-test-state.json
-Pipfile.lock
+.cloudless

--- a/tests/cli_blueprint_tester_fixture/.gitignore
+++ b/tests/cli_blueprint_tester_fixture/.gitignore
@@ -1,2 +1,1 @@
-blueprint-test-state.json
-Pipfile.lock
+.cloudless

--- a/tests/cli_image_build_fixture/.gitignore
+++ b/tests/cli_image_build_fixture/.gitignore
@@ -1,1 +1,1 @@
-cloudless-image-build-state.json
+.cloudless

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 Test the cloudless command line interface.
 """
 import os
+import shutil
 import re
 from unittest.mock import patch
 from click.testing import CliRunner
@@ -15,11 +16,11 @@ AWS_SERVICE_BLUEPRINT = os.path.join(EXAMPLES_DIR, "base-image", "aws_blueprint.
 # Get the blueprint locations relative to the test script
 BLUEPRINT_DIR = os.path.join(os.path.dirname(__file__), "cli_blueprint_tester_fixture")
 BLUEPRINT_TEST_CONFIGURATION = os.path.join(BLUEPRINT_DIR, "blueprint-test-configuration.yml")
-BLUEPRINT_TEST_STATE = os.path.join(BLUEPRINT_DIR, "blueprint-test-state.json")
+BLUEPRINT_TEST_STATE = os.path.join(BLUEPRINT_DIR, ".cloudless")
 
 IMAGE_DIR = os.path.join(os.path.dirname(__file__), "cli_image_build_fixture")
 IMAGE_BUILD_CONFIGURATION = os.path.join(IMAGE_DIR, "image-build-configuration.yml")
-IMAGE_BUILD_STATE = os.path.join(IMAGE_DIR, "cloudless-image-build-state.json")
+IMAGE_BUILD_STATE = os.path.join(IMAGE_DIR, ".cloudless")
 
 # Make sure we don't leak this from the environment.
 if 'CLOUDLESS_PROFILE' in os.environ:
@@ -283,7 +284,7 @@ def test_service_test_subcommand(mock_config_source):
 
     # Remove state from old tests that may have failed.
     if os.path.exists(BLUEPRINT_TEST_STATE):
-        os.remove(BLUEPRINT_TEST_STATE)
+        shutil.rmtree(BLUEPRINT_TEST_STATE)
 
     # Do some mock weirdness to make sure our commands get the right values for the default profile.
     mock_config_source = mock_config_source.return_value
@@ -296,7 +297,7 @@ def test_service_test_subcommand(mock_config_source):
         r'Service test group with provider: mock-aws\n'
         r'Deploy complete!\n'
         r'To log in, run:\n'
-        r'ssh -i /.*/tests/cli_blueprint_tester_fixture/id_rsa_test cloudless_service_test@.*\n'))
+        r'ssh -i /.*/tests/.*/.cloudless/id_rsa_test cloudless_service_test@.*\n'))
     assert result.exception is None
     assert result.exit_code == 0
 
@@ -305,7 +306,7 @@ def test_service_test_subcommand(mock_config_source):
         r'Service test group with provider: mock-aws\n'
         r'Check complete!\n'
         r'To log in, run:\n'
-        r'ssh -i /.*/tests/cli_blueprint_tester_fixture/id_rsa_test cloudless_service_test@.*\n'))
+        r'ssh -i /.*/tests/.*/.cloudless/id_rsa_test cloudless_service_test@.*\n'))
     assert result.exception is None
     assert result.exit_code == 0
 
@@ -433,14 +434,14 @@ def test_image_build_subcommand(mock_config_source):
 
     # Remove state from old tests that may have failed.
     if os.path.exists(IMAGE_BUILD_STATE):
-        os.remove(IMAGE_BUILD_STATE)
+        shutil.rmtree(IMAGE_BUILD_STATE)
 
     result = runner.invoke(get_cldls(), ['image-build', 'deploy', IMAGE_BUILD_CONFIGURATION])
     assert result.exception is None
     assert result.output == (pytest_regex(
         r'image group with provider: mock-aws\n'
         r'Successfully deployed!  Log in with:\n'
-        r'ssh -i /.*/tests/cli_image_build_fixture/id_rsa_image_build cloudless_image_build@.*\n'))
+        r'ssh -i /.*/tests/.*/.cloudless/id_rsa_image_build cloudless_image_build@.*\n'))
     assert result.exit_code == 0
 
     result = runner.invoke(get_cldls(), ['image-build', 'configure', IMAGE_BUILD_CONFIGURATION])

--- a/tests/test_image_builder.py
+++ b/tests/test_image_builder.py
@@ -52,6 +52,13 @@ class MockFileSystemWrapper:
         """
         del self.files[path]
 
+    # pylint:disable=no-self-use, unused-argument
+    def mkdir(self, path):
+        """
+        Make the directory at the given path.
+        """
+        return True
+
 @pytest.fixture
 def mock_filesystem():
     """
@@ -74,6 +81,13 @@ class MockImageBuildConfiguration:
         Get directory of the file behind this configuration.
         """
         return "/test-directory"
+
+    # pylint:disable=no-self-use
+    def get_state_dir(self):
+        """
+        Get directory of the file behind this configuration.
+        """
+        return "/test-directory/.cloudless/"
 
     # pylint:disable=no-self-use
     def get_blueprint_path(self):


### PR DESCRIPTION
This is for the image build and the state testing commands.  Before this change they would put temporary keys and the JSON file in the top level directory, which was non ideal in a lot of ways.

Ideally, this would have smarter namespacing (perhaps on the profile) but this is a step in that direction.