### PR TITLE
Speed up GCE client by only creating driver once

### DIFF
--- a/cloudless/providers/gce/driver.py
+++ b/cloudless/providers/gce/driver.py
@@ -6,14 +6,21 @@ that.
 """
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
+from cloudless.providers.gce.log import logger
+
+
+DRIVER = None
 
 
 def get_gce_driver(credentials):
     """
     Uses the given credentials to get a GCE driver object from libcloud.
     """
-    compute_engine_driver = get_driver(Provider.GCE)
-    driver = compute_engine_driver(user_id=credentials["user_id"],
-                                   key=credentials["key"],
-                                   project=credentials["project"])
-    return driver
+    global DRIVER
+    if not DRIVER:
+        logger.debug("GCE driver not initialized, creating.")
+        compute_engine_driver = get_driver(Provider.GCE)
+        DRIVER = compute_engine_driver(user_id=credentials["user_id"],
+                                       key=credentials["key"],
+                                       project=credentials["project"])
+    return DRIVER


### PR DESCRIPTION
This was making the command line very slow, as each class that talks to GCE called this function, causing many network calls for every command just to set up the connections.