### PR TITLE
Command to dump ssh credentials for test service

### DIFF
--- a/cloudless/testutils/blueprint_tester.py
+++ b/cloudless/testutils/blueprint_tester.py
@@ -191,6 +191,19 @@ def verify(client, config):
     logger.info("Verify successful!")
     return (service, state["ssh_username"], private_key_path(config_obj))
 
+def load_config_for_cli(client, config):
+    """
+    Try to load the configuration for an existing
+    """
+    logger.debug("Running load_config_for_cli on: %s", config)
+    config_obj = BlueprintTestConfiguration(config)
+    state = get_state(config_obj)
+    if not state:
+        return None
+    network = client.network.get(state["network_name"])
+    service = client.service.get(network, state["service_name"])
+    return (service, state["ssh_username"], private_key_path(config_obj))
+
 def teardown(client, config):
     """
     Destroy all services in this network, and destroy the network.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,12 +301,20 @@ def test_service_test_subcommand(mock_config_source):
     assert result.exception is None
     assert result.exit_code == 0
 
+    result = runner.invoke(get_cldls(), ['service-test', 'credentials',
+                                         BLUEPRINT_TEST_CONFIGURATION])
+    assert result.output == (pytest_regex(
+        r'Service test group with provider: mock-aws\n'
+        r'Config loaded!\n'
+        r'To log in, run:\n'
+        r'ssh -i /.*/tests/.*/.cloudless/id_rsa_test cloudless_service_test@.*\n'))
+    assert result.exception is None
+    assert result.exit_code == 0
+
     result = runner.invoke(get_cldls(), ['service-test', 'check', BLUEPRINT_TEST_CONFIGURATION])
     assert result.output == (pytest_regex(
         r'Service test group with provider: mock-aws\n'
-        r'Check complete!\n'
-        r'To log in, run:\n'
-        r'ssh -i /.*/tests/.*/.cloudless/id_rsa_test cloudless_service_test@.*\n'))
+        r'Check complete!\n'))
     assert result.exception is None
     assert result.exit_code == 0
 


### PR DESCRIPTION
This was inconvenient, and involved going into the JSON file to get these credentials.  This just reads the JSON file and prints the right SSH command to make it easier to pick up work after logging out.