### PR TITLE
Prepare to release cloudless v0.0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6] - 2018-11-14
+### Added
+- Add "credentials" subcommand to the "service-test" command to dump SSH
+  credentials for currently deployed service.
+- Add contributor guide and initial list of known modules.
+
+### Changed
+- Fix errors in code examples in README.
+- Update botocore, moto, and other package dependencies.
+
 ## [0.0.5] - 2018-10-15
 ### Added
 - Add documentation about how to set up CLI auto completion

--- a/cloudless/__version__.py
+++ b/cloudless/__version__.py
@@ -4,7 +4,7 @@ Cloudless Package Information
 __title__ = 'cloudless'
 __description__ = 'The cloudless infrastructure project.'
 __url__ = 'https://github.com/sverch/cloudless'
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 __author__ = 'Shaun Verch'
 __author_email__ = 'shaun@getcloudless.com'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
Has a few minor changes, and fixes the broken installation (because some packages got updated).

This is also needed to test: https://github.com/getcloudless/cloudless/pull/65 since I'm pretty sure it's still an issue but wasn't able to reproduce with test pypi.