### PR TITLE
Set AWS profile in cloudless profile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow setting "profile" in the AWS credentials to select a specific AWS
+  profile.
 
 ## [0.0.7] - 2018-11-15
 ### Changed

--- a/cloudless/cli/init.py
+++ b/cloudless/cli/init.py
@@ -32,5 +32,11 @@ def add_init_group(cldls):
             credentials["user_id"] = click.prompt('Please enter gce user id', type=str).strip()
             credentials["key"] = click.prompt('Please enter path to gce key file', type=str).strip()
             credentials["project"] = click.prompt('Please enter gce project name', type=str).strip()
+        if provider == 'aws':
+            click.echo('You can explicitly set an AWS profile for a cloudless profile.')
+            click.echo('Default is unset, which uses your AWS_PROFILE environment variable.')
+            aws_profile = click.prompt('Please enter aws profile', type=str).strip()
+            if aws_profile:
+                credentials["profile"] = aws_profile
         cloudless.profile.save_profile(ctx.obj['PROFILE'], {"provider": provider,
                                                             "credentials": credentials})

--- a/cloudless/providers/aws/image.py
+++ b/cloudless/providers/aws/image.py
@@ -12,8 +12,9 @@ class ImageClient:
     """
 
     def __init__(self, credentials):
-        self.image = cloudless.providers.aws.impl.image.ImageClient(boto3, credentials,
-                                                                    mock=True)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.image = cloudless.providers.aws.impl.image.ImageClient(boto3, mock=True)
 
     def create(self, name, service):
         """

--- a/cloudless/providers/aws/impl/asg.py
+++ b/cloudless/providers/aws/impl/asg.py
@@ -44,11 +44,8 @@ class ASG:
     Autoscaling groups helpers class.
     """
 
-    def __init__(self, driver, credentials):
+    def __init__(self, driver):
         self.driver = driver
-        if credentials:
-            # Currently only using the global defaults is supported
-            raise NotImplementedError("Passing credentials not implemented")
 
     def _describe_launch_configuration(self, asg_name):
         autoscaling = self.driver.client("autoscaling")

--- a/cloudless/providers/aws/impl/availability_zones.py
+++ b/cloudless/providers/aws/impl/availability_zones.py
@@ -9,11 +9,8 @@ class AvailabilityZones:
     """
     Client object for getting availability zones for AWS.
     """
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        if credentials:
-            # Currently only using the global defaults is supported
-            raise NotImplementedError("Passing credentials not implemented")
         self.mock = mock
 
     def get_availability_zones(self):

--- a/cloudless/providers/aws/impl/image.py
+++ b/cloudless/providers/aws/impl/image.py
@@ -21,11 +21,10 @@ class ImageClient:
     This is the object through which all image related calls are made for AWS.
     """
 
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        self.credentials = credentials
         self.mock = mock
-        self.asg = ASG(driver, credentials)
+        self.asg = ASG(driver)
 
     # pylint:disable=too-many-locals
     def create(self, name, service):

--- a/cloudless/providers/aws/impl/internet_gateways.py
+++ b/cloudless/providers/aws/impl/internet_gateways.py
@@ -11,11 +11,8 @@ class InternetGateways:
     Internet Gateways helpers class.
     """
 
-    def __init__(self, driver, credentials):
+    def __init__(self, driver):
         self.driver = driver
-        if credentials:
-            # Currently only using the global defaults is supported
-            raise NotImplementedError("Passing credentials not implemented")
 
     def route_count(self, vpc_id, igw_id):
         """

--- a/cloudless/providers/aws/impl/network.py
+++ b/cloudless/providers/aws/impl/network.py
@@ -26,11 +26,10 @@ class NetworkClient:
     This is the object through which all network related calls are made for AWS.
     """
 
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        self.credentials = credentials
         self.mock = mock
-        self.internet_gateways = InternetGateways(driver, credentials)
+        self.internet_gateways = InternetGateways(driver)
 
     def create(self, name, blueprint):
         """

--- a/cloudless/providers/aws/impl/paths.py
+++ b/cloudless/providers/aws/impl/paths.py
@@ -20,12 +20,11 @@ class PathsClient:
     """
     Client object to interact with paths between resources.
     """
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        self.credentials = credentials
         self.mock = mock
-        self.service = cloudless.providers.aws.impl.service.ServiceClient(driver, credentials, mock)
-        self.asg = ASG(driver, credentials)
+        self.service = cloudless.providers.aws.impl.service.ServiceClient(driver, mock)
+        self.asg = ASG(driver)
 
     def _extract_service_info(self, source, destination, port):
         """

--- a/cloudless/providers/aws/impl/security_groups.py
+++ b/cloudless/providers/aws/impl/security_groups.py
@@ -17,11 +17,8 @@ class SecurityGroups:
     Security Groups helpers class.
     """
 
-    def __init__(self, driver, credentials):
+    def __init__(self, driver):
         self.driver = driver
-        if credentials:
-            # Currently only using the global defaults is supported
-            raise NotImplementedError("Passing credentials not implemented")
 
     def create(self, name, vpc_id):
         ec2 = self.driver.client("ec2")

--- a/cloudless/providers/aws/impl/service.py
+++ b/cloudless/providers/aws/impl/service.py
@@ -33,16 +33,13 @@ class ServiceClient:
     Client object to manage instances.
     """
 
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        self.credentials = credentials
         self.mock = mock
-        self.subnetwork = cloudless.providers.aws.impl.subnetwork.SubnetworkClient(driver,
-                                                                                   credentials,
-                                                                                   mock)
-        self.network = cloudless.providers.aws.impl.network.NetworkClient(driver, credentials)
-        self.asg = ASG(driver, credentials)
-        self.security_groups = SecurityGroups(driver, credentials)
+        self.subnetwork = cloudless.providers.aws.impl.subnetwork.SubnetworkClient(driver, mock)
+        self.network = cloudless.providers.aws.impl.network.NetworkClient(driver)
+        self.asg = ASG(driver)
+        self.security_groups = SecurityGroups(driver)
 
     # pylint: disable=too-many-arguments, too-many-locals
     def create(self, network, service_name, blueprint, template_vars=None, count=None):

--- a/cloudless/providers/aws/impl/subnets.py
+++ b/cloudless/providers/aws/impl/subnets.py
@@ -18,11 +18,8 @@ class Subnets:
     Subnets helpers class.
     """
 
-    def __init__(self, driver, credentials):
+    def __init__(self, driver):
         self.driver = driver
-        if credentials:
-            # Currently only using the global defaults is supported
-            raise NotImplementedError("Passing credentials not implemented")
 
     def carve_subnets(self, vpc_id, vpc_cidr, prefix=28, count=3):
         ec2 = self.driver.client("ec2")

--- a/cloudless/providers/aws/impl/subnetwork.py
+++ b/cloudless/providers/aws/impl/subnetwork.py
@@ -28,13 +28,12 @@ class SubnetworkClient:
     Client object to manage subnetworks.
     """
 
-    def __init__(self, driver, credentials, mock=False):
+    def __init__(self, driver, mock=False):
         self.driver = driver
-        self.credentials = credentials
-        self.network = cloudless.providers.aws.impl.network.NetworkClient(driver, credentials, mock)
-        self.internet_gateways = InternetGateways(driver, credentials)
-        self.subnets = Subnets(driver, credentials)
-        self.availability_zones = AvailabilityZones(driver, credentials, mock)
+        self.network = cloudless.providers.aws.impl.network.NetworkClient(driver, mock)
+        self.internet_gateways = InternetGateways(driver)
+        self.subnets = Subnets(driver)
+        self.availability_zones = AvailabilityZones(driver, mock)
 
     def create(self, network, subnetwork_name, blueprint):
         """

--- a/cloudless/providers/aws/network.py
+++ b/cloudless/providers/aws/network.py
@@ -15,8 +15,9 @@ class NetworkClient:
     """
 
     def __init__(self, credentials):
-        self.network = cloudless.providers.aws.impl.network.NetworkClient(boto3, credentials,
-                                                                          mock=False)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.network = cloudless.providers.aws.impl.network.NetworkClient(boto3, mock=False)
 
     def create(self, name, blueprint):
         """

--- a/cloudless/providers/aws/paths.py
+++ b/cloudless/providers/aws/paths.py
@@ -14,7 +14,9 @@ class PathsClient:
     Client object to interact with paths between resources.
     """
     def __init__(self, credentials):
-        self.paths = cloudless.providers.aws.impl.paths.PathsClient(boto3, credentials, mock=False)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.paths = cloudless.providers.aws.impl.paths.PathsClient(boto3, mock=False)
 
 
     def add(self, source, destination, port):

--- a/cloudless/providers/aws/service.py
+++ b/cloudless/providers/aws/service.py
@@ -15,8 +15,9 @@ class ServiceClient:
     """
 
     def __init__(self, credentials):
-        self.service = cloudless.providers.aws.impl.service.ServiceClient(boto3, credentials,
-                                                                          mock=False)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.service = cloudless.providers.aws.impl.service.ServiceClient(boto3, mock=False)
 
     # pylint: disable=too-many-arguments
     def create(self, network, service_name, blueprint, template_vars, count):

--- a/cloudless/providers/aws_mock/image.py
+++ b/cloudless/providers/aws_mock/image.py
@@ -14,9 +14,10 @@ class ImageClient:
     This is the object through which all image related calls are made for AWS.
     """
 
+    # You can set a "profile" in credentials, but that doesn't matter for moto
+    # pylint: disable=unused-argument
     def __init__(self, credentials):
-        self.image = cloudless.providers.aws.impl.image.ImageClient(boto3, credentials,
-                                                                    mock=True)
+        self.image = cloudless.providers.aws.impl.image.ImageClient(boto3, mock=True)
 
     def create(self, name, service):
         """

--- a/cloudless/providers/aws_mock/network.py
+++ b/cloudless/providers/aws_mock/network.py
@@ -13,9 +13,10 @@ class NetworkClient:
     This is the object through which all network related calls are made for AWS.
     """
 
+    # You can set a "profile" in credentials, but that doesn't matter for moto
+    # pylint: disable=unused-argument
     def __init__(self, credentials):
-        self.network = cloudless.providers.aws.impl.network.NetworkClient(boto3, credentials,
-                                                                          mock=True)
+        self.network = cloudless.providers.aws.impl.network.NetworkClient(boto3, mock=True)
 
     def create(self, name, blueprint):
         """

--- a/cloudless/providers/aws_mock/paths.py
+++ b/cloudless/providers/aws_mock/paths.py
@@ -15,8 +15,11 @@ class PathsClient:
     """
     Client object to interact with paths between resources.
     """
+
+    # You can set a "profile" in credentials, but that doesn't matter for moto
+    # pylint: disable=unused-argument
     def __init__(self, credentials):
-        self.paths = cloudless.providers.aws.impl.paths.PathsClient(boto3, credentials, mock=True)
+        self.paths = cloudless.providers.aws.impl.paths.PathsClient(boto3, mock=True)
 
 
     def add(self, source, destination, port):

--- a/cloudless/providers/aws_mock/service.py
+++ b/cloudless/providers/aws_mock/service.py
@@ -11,9 +11,11 @@ class ServiceClient:
     """
     Cloudless Service Client Object for Mock AWS
     """
+
+    # You can set a "profile" in credentials, but that doesn't matter for moto
+    # pylint: disable=unused-argument
     def __init__(self, credentials):
-        self.service = cloudless.providers.aws.impl.service.ServiceClient(boto3, credentials,
-                                                                          mock=True)
+        self.service = cloudless.providers.aws.impl.service.ServiceClient(boto3, mock=True)
 
     # pylint: disable=too-many-arguments
     def create(self, network, service_name, blueprint, template_vars, count):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -89,7 +89,7 @@ def test_image_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_image_test(provider="aws", credentials={})
+    run_image_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 @pytest.mark.gce
 def test_image_gce():

--- a/tests/test_instance_fitter.py
+++ b/tests/test_instance_fitter.py
@@ -82,7 +82,7 @@ def test_instance_fitter_aws():
     """
     Test instance fitter with AWS and global configuration.
     """
-    run_instance_fitter_test(provider="aws", credentials={})
+    run_instance_fitter_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 @pytest.mark.gce
 def test_instance_fitter_gce():

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -61,7 +61,7 @@ def test_network_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_network_test(provider="aws", credentials={})
+    run_network_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 
 @pytest.mark.gce

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -71,7 +71,7 @@ def test_paths_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_paths_test(provider="aws", credentials={})
+    run_paths_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 @pytest.mark.gce
 def test_paths_gce():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -182,7 +182,7 @@ def test_instances_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_instances_test(provider="aws", credentials={})
+    run_instances_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 @pytest.mark.gce
 def test_instances_gce():

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -112,7 +112,7 @@ def test_ssh_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_ssh_test(provider="aws", credentials={})
+    run_ssh_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
 
 @pytest.mark.gce
 def test_ssh_gce():


### PR DESCRIPTION
This allows a Cloudless profile to use a specific AWS profile.

A lot needed to be changed because the credentials object was threaded through everywhere and didn't need to be as I decided to implement this.

Downside is that this sets the profile for boto globally if you use cloudless and then boto, but this is going to require some major refactoring anyway.