### PR TITLE
Add support for profiles in python API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow setting "profile" in the AWS credentials to select a specific AWS
   profile.
+- Support using profiles in the python api with the `profile` argument.
 
 ## [0.0.7] - 2018-11-15
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cldls network list
 
 This will set the "default" profile to use the "gce" backend.  You can change
 the profile by passing `--profile` to cloudless or setting the
-`CLOUDLESS_PROFILE` environment variable.
+`CLOUDLESS_PROFILE` environment variable.  See [Profiles](#profiles) for more information.
 
 ### Amazon Web Services Credentials
 
@@ -63,7 +63,7 @@ cldls network list
 
 This will set the "default" profile to use the "aws" backend.  You can change
 the profile by passing `--profile` to cloudless or setting the
-`CLOUDLESS_PROFILE` environment variable.
+`CLOUDLESS_PROFILE` environment variable.  See [Profiles](#profiles) for more information.
 
 ### Simple Service
 
@@ -97,6 +97,16 @@ For example, for bash puth this in your .bashrc:
 ```shell
 eval "$(_CLDLS_COMPLETE=source cldls)"
 ```
+
+## Profiles
+
+Both the API and the command line support using profiles that are created with `cldls init`.  The
+order of priority for loading profiles is:
+
+1. Explicitly set via the `profile` argument to `cloudless.Client` in the python api, or via the
+   `--profile` option to the `cldls` command line.
+2. Set in the `CLOUDLESS_PROFILE` environment variable.
+3. `"default"`
 
 ## Client Setup In Python API
 
@@ -138,6 +148,9 @@ client = cloudless.Client("gce", credentials={
     "project": os.environ['CLOUDLESS_GCE_PROJECT_NAME']})
 ```
 
+If you want to avoid having to pass all this configuration explicitly to the client object, you can
+use a [Cloudless Profile](#profiles).
+
 ### Amazon Web Services Client
 
 Currently no credentials can be passed in as arguments for the AWS provider
@@ -148,13 +161,17 @@ credential setup
 documentation](https://boto3.readthedocs.io/en/latest/guide/configuration.html)
 for more details.
 
-Once you have set up your credentials, you can run the following to create an
-AWS client:
+Once you have set up your credentials, you can run the following to create an AWS client that uses
+the "default" aws profile (if you pass an empty credentials object, this cloudless profile will use
+whatever the `AWS_PROFILE` environment variable is set to, which might be confusing):
 
 ```python
 import cloudless
-client = cloudless.Client("aws", credentials={})
+client = cloudless.Client("aws", credentials={"profile": "default"})
 ```
+
+If you want to avoid having to pass all this configuration explicitly to the client object, you can
+use a [Cloudless Profile](#profiles).
 
 ### Mock Amazon Web Services Client
 
@@ -480,5 +497,5 @@ tox -e gce
 tox -e aws
 ```
 
-For GCE, you must set `CLOUDLESS_GCE_USER_ID`, `CLOUDLESS_GCE_CREDENTIALS_PATH`, and
-`CLOUDLESS_GCE_PROJECT_NAME` as described above.
+These will use the `gce-cloudless-test` and `aws-cloudless-test` cloudless
+profiles respectively.  See [Profiles](#profiles) for more information.

--- a/cloudless/cli/cldls.py
+++ b/cloudless/cli/cldls.py
@@ -1,7 +1,6 @@
 """
 Cloudless command line interface definitions.
 """
-import os
 import logging
 import click
 from click_repl import register_repl
@@ -14,6 +13,7 @@ from cloudless.cli.image import add_image_group
 from cloudless.cli.image_build import add_image_build_group
 from cloudless.cli.utils import NaturalOrderGroup
 import cloudless
+import cloudless.profile
 
 cloudless.set_level(logging.INFO)
 cloudless.set_global_level(logging.WARN)
@@ -39,12 +39,7 @@ def get_cldls():
         if debug:
             click.echo('Enabling debug logging.')
             cloudless.set_level(logging.DEBUG)
-        if profile:
-            ctx.obj['PROFILE'] = profile
-        elif "CLOUDLESS_PROFILE" in os.environ:
-            ctx.obj['PROFILE'] = os.environ["CLOUDLESS_PROFILE"]
-        else:
-            ctx.obj['PROFILE'] = "default"
+        ctx.obj['PROFILE'] = cloudless.profile.select_profile(profile)
 
     add_init_group(cldls)
     add_network_group(cldls)

--- a/cloudless/cli/utils.py
+++ b/cloudless/cli/utils.py
@@ -50,6 +50,9 @@ class NaturalOrderAliasedGroup(NaturalOrderGroup):
 def handle_profile_for_cli(ctx):
     """
     Loads the profile and sets the proper fields on the context object for the command line.
+
+    Note, the API does handle the profile as well, but this is an attempt to return nice errors to
+    the user.  It would be nice to make this cleaner/deduplicate code.
     """
     profile = cloudless.profile.load_profile(ctx.obj['PROFILE'])
     if not profile:

--- a/cloudless/profile.py
+++ b/cloudless/profile.py
@@ -51,3 +51,17 @@ def load_profile(profile):
     file_config_source = FileConfigSource()
     config = file_config_source.load()
     return config.get(profile, None)
+
+def select_profile(profile=None):
+    """
+    Figure out what profile we should use.  Order of precedence:
+
+    1. Explicitly set profile
+    2. CLOUDLESS_PROFILE environment variable
+    3. "default"
+    """
+    if profile:
+        return profile
+    if "CLOUDLESS_PROFILE" in os.environ:
+        return os.environ["CLOUDLESS_PROFILE"]
+    return "default"

--- a/cloudless/util/exceptions.py
+++ b/cloudless/util/exceptions.py
@@ -18,6 +18,13 @@ class DisallowedOperationException(Exception):
     pass
 
 
+class ProfileNotFoundException(Exception):
+    """
+    Could not find the provided profile.
+    """
+    pass
+
+
 class NotEnoughIPSpaceException(Exception):
     """
     Could not allocate the given CIDR range.

--- a/tests/test_instance_fitter.py
+++ b/tests/test_instance_fitter.py
@@ -1,7 +1,6 @@
 """
 Test instance fitter.
 """
-import os
 import pytest
 import cloudless
 from cloudless.util.instance_fitter import get_fitting_instance
@@ -57,21 +56,21 @@ initialization:
   - path: "N/A - only to test instance fitter"
 """
 
-def run_instance_fitter_test(provider, credentials):
+def run_instance_fitter_test(profile=None, provider=None, credentials=None):
     """
     Test that we get the proper instance sizes for the given provider.
     """
 
     # Get the client for this test
-    client = cloudless.Client(provider, credentials)
+    client = cloudless.Client(profile, provider, credentials)
 
     # If no memory, cpu, or storage is passed in, find the cheapest.
-    if provider == "aws":
+    if client.provider == "aws":
         assert get_fitting_instance(client.service,
                                     ServiceBlueprint(SMALL_INSTANCE_BLUEPRINT)) == "t2.small"
         assert get_fitting_instance(client.service,
                                     ServiceBlueprint(LARGE_INSTANCE_BLUEPRINT)) == "m5.xlarge"
-    if provider == "gce":
+    if client.provider == "gce":
         assert get_fitting_instance(client.service,
                                     ServiceBlueprint(SMALL_INSTANCE_BLUEPRINT)) == "n1-highcpu-4"
         assert get_fitting_instance(client.service,
@@ -82,14 +81,11 @@ def test_instance_fitter_aws():
     """
     Test instance fitter with AWS and global configuration.
     """
-    run_instance_fitter_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
+    run_instance_fitter_test(profile="aws-cloudless-test")
 
 @pytest.mark.gce
 def test_instance_fitter_gce():
     """
     Test instance fitter with GCE and below environment configuration.
     """
-    run_instance_fitter_test(provider="gce", credentials={
-        "user_id": os.environ['CLOUDLESS_GCE_USER_ID'],
-        "key": os.environ['CLOUDLESS_GCE_CREDENTIALS_PATH'],
-        "project": os.environ['CLOUDLESS_GCE_PROJECT_NAME']})
+    run_instance_fitter_test(profile="gce-cloudless-test")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,13 +14,13 @@ NETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
                                  "network", "blueprint.yml")
 
 
-def run_network_test(provider, credentials):
+def run_network_test(profile=None, provider=None, credentials=None):
     """
     Test network management on the given provider.
     """
 
     # Get the client for this test
-    client = cloudless.Client(provider, credentials)
+    client = cloudless.Client(profile, provider, credentials)
 
     # Get somewhat unique network names
     network1_name = generate_unique_name("network1")
@@ -61,7 +61,7 @@ def test_network_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_network_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
+    run_network_test(profile="aws-cloudless-test")
 
 
 @pytest.mark.gce
@@ -69,7 +69,4 @@ def test_network_gce():
     """
     Run tests against real GCE (environment variables below must be set).
     """
-    run_network_test(provider="gce", credentials={
-        "user_id": os.environ['CLOUDLESS_GCE_USER_ID'],
-        "key": os.environ['CLOUDLESS_GCE_CREDENTIALS_PATH'],
-        "project": os.environ['CLOUDLESS_GCE_PROJECT_NAME']})
+    run_network_test(profile="gce-cloudless-test")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -13,24 +13,24 @@ AWS_SERVICE_BLUEPRINT = os.path.join(EXAMPLES_DIR, "base-image", "aws_blueprint.
 GCE_SERVICE_BLUEPRINT = os.path.join(EXAMPLES_DIR, "base-image", "gce_blueprint.yml")
 
 
-def run_paths_test(provider, credentials):
+def run_paths_test(profile=None, provider=None, credentials=None):
     """
     Test that the path management works against the given provider.
     """
 
     # Get the client for this test
-    client = cloudless.Client(provider, credentials)
+    client = cloudless.Client(profile, provider, credentials)
 
     # Get a somewhat unique network name
     network_name = generate_unique_name("unittest")
 
     # Provision all the resources
     test_network = client.network.create(network_name, blueprint=NETWORK_BLUEPRINT)
-    if provider in ["aws", "mock-aws"]:
+    if client.provider in ["aws", "mock-aws"]:
         lb_service = client.service.create(test_network, "web-lb", AWS_SERVICE_BLUEPRINT, {})
         web_service = client.service.create(test_network, "web", AWS_SERVICE_BLUEPRINT, {})
     else:
-        assert provider == "gce"
+        assert client.provider == "gce"
         lb_service = client.service.create(test_network, "web-lb", GCE_SERVICE_BLUEPRINT, {})
         web_service = client.service.create(test_network, "web", GCE_SERVICE_BLUEPRINT, {})
 
@@ -71,14 +71,11 @@ def test_paths_aws():
     """
     Run tests against real AWS (using global configuration).
     """
-    run_paths_test(provider="aws", credentials={"profile": "aws-cloudless-test"})
+    run_paths_test(profile="aws-cloudless-test")
 
 @pytest.mark.gce
 def test_paths_gce():
     """
     Run tests against real GCE (environment variables below must be set).
     """
-    run_paths_test(provider="gce", credentials={
-        "user_id": os.environ['CLOUDLESS_GCE_USER_ID'],
-        "key": os.environ['CLOUDLESS_GCE_CREDENTIALS_PATH'],
-        "project": os.environ['CLOUDLESS_GCE_PROJECT_NAME']})
+    run_paths_test(profile="gce-cloudless-test")


### PR DESCRIPTION
Allows usage of profiles in the python API so that you don't always have to pass everything in explicitly.

Fixes: https://github.com/getcloudless/cloudless/issues/56