### PR TITLE
Use released version of PyYaml with safe_load

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use old non prerelease PyYaml version but use safe_load for security.
 
 ## [0.0.8] - 2019-03-01
 ### Added

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -91,17 +91,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:44377f0bd47891502de56629ec45d4c0f6720dd85b61d8d2004fb1310859ef74",
-                "sha256:ca4663710f25144e976becc72c9775f84c1c2a7285b78fd24c383668d09d842b"
+                "sha256:30badbe5dab638e764e23125479e848c446a9669ef0612b8d8d305738bc442d3",
+                "sha256:c2dd70cb1ee2c49aed8bd3782fa82a766ad68921e1230620d41f4efe3b16bb75"
             ],
-            "version": "==1.9.104"
+            "version": "==1.9.106"
         },
         "botocore": {
             "hashes": [
-                "sha256:08fbeba08b6dd947b9ba1b3d07e3a0574e6fa2fcc4a06db1752bc6ca234e27b8",
-                "sha256:99b4302571675ac4b692275634e14e0c76009da54520af3e77bd4b29d7844c5e"
+                "sha256:60f4f62075d7b274360f74f220e9e56fb404bebd592ccb221e3f5333ceb1febb",
+                "sha256:bff336cccf1ed2b7cab54bb802e135a063cb7614271c6dacd2f49ecbc26df7da"
             ],
-            "version": "==1.12.104"
+            "version": "==1.12.106"
         },
         "certifi": {
             "hashes": [
@@ -467,13 +467,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
-                "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
-                "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
-                "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
-                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "version": "==4.2b4"
+            "version": "==3.13"
         },
         "requests": {
             "hashes": [
@@ -932,10 +938,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:5a3ecdfbde67a4a3b3111301c4d64a5b71cf862c8c42958d30cf3253df1f29dd",
-                "sha256:dffd40d19ab0168c02cf936de59590a3c0f2c8c4a36f363fcf3dae18728dc94e"
+                "sha256:6aebaf4dd2568a0094225ebbca987859e369e3e5c22dc7d52e5406d504890417",
+                "sha256:984d7e607b0a5d1329425dd8845bd971b957424b5ba664729fab51ab8c11bc39"
             ],
-            "version": "==16.4.1"
+            "version": "==16.4.3"
         },
         "wrapt": {
             "hashes": [

--- a/cloudless/cli/service.py
+++ b/cloudless/cli/service.py
@@ -38,7 +38,7 @@ def add_service_group(cldls):
         """
         if var_file:
             with open(var_file, 'r') as stream:
-                var_file_contents = yaml.load(stream)
+                var_file_contents = yaml.safe_load(stream)
         else:
             var_file_contents = {}
         network_object = get_network_for_cli(ctx, network)

--- a/cloudless/profile.py
+++ b/cloudless/profile.py
@@ -22,7 +22,7 @@ class FileConfigSource:
         if not os.path.exists(self.config_path):
             return None
         with open(self.config_path, 'r') as config_file:
-            return yaml.load(config_file)
+            return yaml.safe_load(config_file)
 
     def save(self, config):
         """

--- a/cloudless/util/blueprint.py
+++ b/cloudless/util/blueprint.py
@@ -29,7 +29,7 @@ class Blueprint:
     def __init__(self, blueprint, blueprint_path="./"):
         logger.debug("Creating blueprint from data: %s", blueprint)
         try:
-            self.blueprint = yaml.load(blueprint)
+            self.blueprint = yaml.safe_load(blueprint)
         except yaml.YAMLError as exc:
             logger.error("Error parsing blueprint: %s", exc)
             raise exc

--- a/cloudless/util/blueprint_test_configuration.py
+++ b/cloudless/util/blueprint_test_configuration.py
@@ -19,7 +19,7 @@ class BlueprintTestConfiguration:
     def __init__(self, config):
         with open(config, 'r') as stream:
             try:
-                self.config = yaml.load(stream)
+                self.config = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 logger.error("Error parsing config: %s", exc)
                 raise exc

--- a/cloudless/util/image_build_configuration.py
+++ b/cloudless/util/image_build_configuration.py
@@ -20,7 +20,7 @@ class ImageBuildConfiguration:
     def __init__(self, config):
         with open(config, 'r') as stream:
             try:
-                self.config = yaml.load(stream)
+                self.config = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 logger.error("Error parsing config: %s", exc)
                 raise exc

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ NAME = 'cloudless'
 REQUIRED = [
     'boto3>=1.9.39,<1.10.0',
     'botocore>=1.12.39,<1.13.0',
-    'PyYaml>=4.2b1,<4.3',
+    # This is vulnerable to https://github.com/yaml/pyyaml/issues/207, but unfortunately there's no
+    # released version that fixes that at this moment.  For now, use safe_load everywhere.
+    'PyYaml>=3.13,<4.3',
     'jinja2>=2.10,<3.0',
     # This pytest dependency is only for the module tester.  Perhaps this should
     # be a separate module eventually.


### PR DESCRIPTION
Using the beta version may include the security fix, but it causes installation issues.  Using safe_yaml is safe across versions according to https://github.com/yaml/pyyaml/issues/207.