### PR TITLE
Update pylint to 2.3.1 fix linter errors

### DIFF
--- a/cloudless/providers/aws/impl/network.py
+++ b/cloudless/providers/aws/impl/network.py
@@ -94,11 +94,12 @@ class NetworkClient:
             raise BadEnvironmentStateException(
                 "Expected to find at most one VPC named: %s, "
                 "output: %s" % (name, vpcs))
-        elif not vpcs["Vpcs"]:
+
+        if not vpcs["Vpcs"]:
             return None
-        else:
-            return canonicalize_network_info(name, vpcs["Vpcs"][0],
-                                             self.driver.session.Session().region_name)
+
+        return canonicalize_network_info(name, vpcs["Vpcs"][0],
+                                         self.driver.session.Session().region_name)
 
     # pylint: disable=no-self-use
     def destroy(self, network):

--- a/cloudless/util/exceptions.py
+++ b/cloudless/util/exceptions.py
@@ -8,53 +8,45 @@ class BadEnvironmentStateException(Exception):
     Throw this when the cloud environment you're deploying to is not in the
     state it should be (violates some invariant).
     """
-    pass
 
 
 class DisallowedOperationException(Exception):
     """
     Trying to do something that's invalid.
     """
-    pass
 
 
 class ProfileNotFoundException(Exception):
     """
     Could not find the provided profile.
     """
-    pass
 
 
 class NotEnoughIPSpaceException(Exception):
     """
     Could not allocate the given CIDR range.
     """
-    pass
 
 
 class OperationTimedOut(Exception):
     """
     Exceeded max retries to perform operation.
     """
-    pass
 
 
 class BlueprintException(Exception):
     """
     Encountered error interpreting Blueprint file.
     """
-    pass
 
 
 class BadConfigurationException(Exception):
     """
     Encountered error interpreting Configuration file.
     """
-    pass
 
 
 class IncompleteOperationException(Exception):
     """
     This is if we are still waiting for something to happen, normally should retry.
     """
-    pass

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ TESTS_REQUIRED = [
     'pytest>=3.8.0,<3.9.0',
     'pytest-xdist>=1.23.0,<1.24.0',
     'tox>=3.2.1,<3.3.0',
-    'pylint>=2.1.1,<2.2.0',
+    'pylint>=2.3.1,<2.4.0',
 ]
 
 # What packages are optional?
@@ -118,7 +118,6 @@ class UploadCommand(Command):
         """
         Unused/noop
         """
-        pass
 
     def run(self):
         """


### PR DESCRIPTION
Pylint may have been using a newer version than it was before which was causing errors, but the version constraint wouldn't let it use the most recent.  This fixes that and fixes the new linter errors caught by 2.3.1.