### PR TITLE
Adding Image model implementation for AWS

### DIFF
--- a/cloudless/providers/aws/image_model.py
+++ b/cloudless/providers/aws/image_model.py
@@ -1,0 +1,59 @@
+"""
+Cloudless Image Model on AWS
+"""
+import boto3
+import dateutil.parser
+import cloudless.model
+from cloudless.types.common import ImageModel
+import cloudless.providers.aws.impl.image
+
+class ImageResourceDriver(cloudless.model.ResourceDriver):
+    """
+    This class is what gets called when the user is trying to interact with a "Image" resource.
+    """
+    def __init__(self, provider, credentials):
+        self.provider = provider
+        self.credentials = credentials
+        super(ImageResourceDriver, self).__init__(provider, credentials)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.driver = boto3
+
+    def create(self, resource_definition):
+        raise NotImplementedError("Image Creation Not Implemented")
+
+    def apply(self, resource_definition):
+        raise NotImplementedError("Image Application Not Implemented")
+
+    def delete(self, resource_definition):
+        raise NotImplementedError("Image Deletion Not Implemented")
+
+    def get(self, resource_definition):
+        image = resource_definition
+
+        def lookup_image(ami_name):
+            """
+            Looks up the image.  The EC2 API supports simple wildcard matching.
+            """
+            ec2 = self.driver.client("ec2")
+            images = ec2.describe_images(Filters=[{"Name": "name",
+                                                   "Values": [ami_name]}])
+            result_image = None
+            for image in images["Images"]:
+                if not result_image:
+                    result_image = image
+                if (dateutil.parser.parse(image["CreationDate"]) >
+                        dateutil.parser.parse(result_image["CreationDate"])):
+                    result_image = image
+            return result_image
+
+        # Get rid of this when I reimplement here, now just for compatibility/testing.
+        # Also do not pass the blueprint.
+        found_image = lookup_image(image.name)
+        if found_image:
+            return [ImageModel(version=image.version, name=found_image["Name"],
+                               id=found_image["ImageId"])]
+        return None
+
+    def flags(self, resource_definition):
+        return []

--- a/cloudless/providers/aws/model.py
+++ b/cloudless/providers/aws/model.py
@@ -3,7 +3,7 @@ Cloudless Model on AWS
 """
 import os
 import cloudless.model
-from cloudless.providers.aws import firewall, network_model
+from cloudless.providers.aws import firewall, network_model, image_model
 
 def get_model(credentials):
     """
@@ -18,4 +18,7 @@ def get_model(credentials):
     model.register("Network",
                    "%s/network.json" % models_dir,
                    network_model.NetworkResourceDriver("aws", credentials))
+    model.register("Image",
+                   "%s/image.json" % models_dir,
+                   image_model.ImageResourceDriver("aws", credentials))
     return model

--- a/cloudless/providers/aws_mock/image_model.py
+++ b/cloudless/providers/aws_mock/image_model.py
@@ -1,0 +1,35 @@
+"""
+Cloudless Image Model on Mock AWS
+"""
+from moto import mock_ec2
+import cloudless.model
+
+@mock_ec2
+class MockImageResourceDriver(cloudless.model.ResourceDriver):
+    """
+    This class is what gets called when the user is trying to interact with a "Image" resource.
+
+    By the time it gets called to interact with "Image" resources, it should be fully initialized
+    and prepared to interact with the backing provider, because that is all configured up front.
+    """
+    def __init__(self, provider, credentials):
+        self.provider = provider
+        self.credentials = credentials
+        self.driver = cloudless.providers.aws.image_model.ImageResourceDriver(provider,
+                                                                              credentials)
+        super(MockImageResourceDriver, self).__init__(provider, credentials)
+
+    def create(self, resource_definition):
+        return self.driver.create(resource_definition)
+
+    def apply(self, resource_definition):
+        return self.driver.apply(resource_definition)
+
+    def delete(self, resource_definition):
+        return self.driver.delete(resource_definition)
+
+    def get(self, resource_definition):
+        return self.driver.get(resource_definition)
+
+    def flags(self, resource_definition):
+        return self.driver.flags(resource_definition)

--- a/cloudless/providers/aws_mock/model.py
+++ b/cloudless/providers/aws_mock/model.py
@@ -3,7 +3,7 @@ Cloudless Model on Mock AWS
 """
 import os
 import cloudless.model
-from cloudless.providers.aws_mock import firewall, network_model
+from cloudless.providers.aws_mock import firewall, network_model, image_model
 
 def get_model(credentials):
     """
@@ -18,4 +18,7 @@ def get_model(credentials):
     model.register("Network",
                    "%s/network.json" % models_dir,
                    network_model.MockNetworkResourceDriver("mock_aws", credentials))
+    model.register("Image",
+                   "%s/image.json" % models_dir,
+                   image_model.MockImageResourceDriver("mock_aws", credentials))
     return model

--- a/cloudless/types/common.py
+++ b/cloudless/types/common.py
@@ -132,3 +132,14 @@ class NetworkModel(Resource):
     availability_zone: Optional[str] = None
     cidr_block: Optional[str] = None
 NetworkModel.schema = load_model("network.json")
+
+@attr.s(auto_attribs=True)
+class ImageModel(Resource):
+    """
+    Simple container to hold image information.
+    """
+    version: str
+    name: str
+    id: Optional[str] = None
+    creation_date: Optional[str] = None
+ImageModel.schema = load_model("image.json")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,18 +1,12 @@
 """
 Tests for model management.
 """
-import os
 import pytest
 import cloudless
 from cloudless.testutils.blueprint_tester import generate_unique_name
-from cloudless.types.common import Firewall, NetworkModel
+from cloudless.types.common import Firewall, NetworkModel, ImageModel
 
-EXAMPLE_BLUEPRINTS_DIR = os.path.join(os.path.dirname(__file__),
-                                      "..", "examples")
-NETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
-                                 "network", "blueprint.yml")
-
-def run_model_test(profile=None, provider=None, credentials=None):
+def run_firewall_model_test(profile=None, provider=None, credentials=None):
     """
     Test model management on the given provider.
     """
@@ -60,27 +54,51 @@ def run_model_test(profile=None, provider=None, credentials=None):
     network_get = client.model.get("Network", network)
     assert not network_get
 
+def run_image_model_test(profile=None, provider=None, credentials=None):
+    """
+    Test image model on the given provider.
+    """
+    client = cloudless.Client(profile, provider, credentials)
+
+    # Create Image model
+    image = ImageModel.fromdict({"name": "*ubuntu*xenial*", "version": "0.0.0",
+                                 "creation_date": "latest"})
+
+    # Make sure the image model is registered
+    assert "Image" in client.model.resources()
+
+    image_get = client.model.get("Image", image)
+    assert len(image_get) == 1
+    assert "ubuntu" in image_get[0].name
+
 
 @pytest.mark.mock_aws
-def test_model_mock():
+def test_firewall_model_mock():
     """
     Run tests using the mock aws driver (moto).
     """
-    run_model_test(provider="mock-aws", credentials={})
+    run_firewall_model_test(provider="mock-aws", credentials={})
+
+@pytest.mark.mock_aws
+def test_image_model_mock():
+    """
+    Run tests using the mock aws driver (moto).
+    """
+    run_image_model_test(provider="mock-aws", credentials={})
 
 
 # Disabling anything besides mock AWS as this API is still in flux
 #@pytest.mark.aws
-#def test_model_aws():
+#def test_firewall_model_aws():
 #    """
 #    Run tests against real AWS (using global configuration).
 #    """
-#    run_model_test(profile="aws-cloudless-test")
+#    run_firewall_model_test(profile="aws-cloudless-test")
 #
 #
 #@pytest.mark.gce
-#def test_model_gce():
+#def test_firewall_model_gce():
 #    """
 #    Run tests against real GCE (environment variables below must be set).
 #    """
-#    run_model_test(profile="gce-cloudless-test")
+#    run_firewall_model_test(profile="gce-cloudless-test")


### PR DESCRIPTION
This is important because it will allow the instance schema to use a
selector to select the image it should be based on, and have that be a
first class citizen (as opposed to now where it's hidden in the
implementation, and somewhat limited).