### PR TITLE
Implement Subnet resource

### DIFF
--- a/cloudless/providers/aws/model.py
+++ b/cloudless/providers/aws/model.py
@@ -3,7 +3,7 @@ Cloudless Model on AWS
 """
 import os
 import cloudless.model
-from cloudless.providers.aws import firewall, network_model, image_model
+from cloudless.providers.aws import firewall, network_model, image_model, subnet_model
 
 def get_model(credentials):
     """
@@ -21,4 +21,7 @@ def get_model(credentials):
     model.register("Image",
                    "%s/image.json" % models_dir,
                    image_model.ImageResourceDriver("aws", credentials))
+    model.register("Subnet",
+                   "%s/subnet.json" % models_dir,
+                   subnet_model.SubnetResourceDriver("aws", credentials, model))
     return model

--- a/cloudless/providers/aws/network_model.py
+++ b/cloudless/providers/aws/network_model.py
@@ -26,14 +26,19 @@ class NetworkResourceDriver(cloudless.model.ResourceDriver):
         # Get rid of this when I reimplement here, now just for compatibility/testing.
         # Also do not pass the blueprint.
         old_network = self.network.create(network.name, None)
-        return NetworkModel(version=network.version, name=old_network.name)
+        return NetworkModel(version=network.version, name=old_network.name,
+                            id=old_network.network_id,
+                            cidr_block=old_network.cidr_block,
+                            region=old_network.region)
 
     def apply(self, resource_definition):
         network = resource_definition
         # Get rid of this when I reimplement here, now just for compatibility/testing.
         # Also do not pass the blueprint.
         old_network = self.network.get(network.name)
-        return NetworkModel(version=network.version, name=old_network.name)
+        return NetworkModel(version=network.version, name=old_network.name,
+                            cidr_block=old_network.cidr_block,
+                            region=old_network.region)
 
     def delete(self, resource_definition):
         network = resource_definition
@@ -49,7 +54,10 @@ class NetworkResourceDriver(cloudless.model.ResourceDriver):
         # Also do not pass the blueprint.
         old_network = self.network.get(network.name)
         if old_network:
-            return [NetworkModel(version=network.version, name=old_network.name)]
+            return [NetworkModel(version=network.version, name=old_network.name,
+                                 id=old_network.network_id,
+                                 cidr_block=old_network.cidr_block,
+                                 region=old_network.region)]
         return None
 
     def flags(self, resource_definition):

--- a/cloudless/providers/aws/subnet_model.py
+++ b/cloudless/providers/aws/subnet_model.py
@@ -1,0 +1,92 @@
+"""
+Cloudless Subnet Model on AWS
+"""
+import boto3
+import cloudless.model
+from cloudless.providers.aws.log import logger
+from cloudless.types.common import SubnetModel
+import cloudless.providers.aws.impl.subnetwork
+from cloudless.util.exceptions import DisallowedOperationException
+
+class SubnetResourceDriver(cloudless.model.ResourceDriver):
+    """
+    Driver for the "Subnet" resource.
+
+    It's a little strange here because subnets in GCE are per region, while subnets in AWS are per
+    availability zone.
+
+    The abstraction provided by this resource is "subnet per region" which means that there is a
+    translation down to AWS.  When you create a "Subnet", AWS will actually create multiple subnets
+    across three regions by default (when possible).  All subnets with the same name, region
+    combination will be treated as a single subnet.
+
+    This raises the problem of availability zones and cidr blocks.  In theory the user should be
+    allowed to explicitly set these, but for now AWS will hardcode max(3, num_available_in_region)
+    availability zones.  Future work to make this explicitly configurable.
+    """
+    def __init__(self, provider, credentials, model):
+        self.provider = provider
+        self.credentials = credentials
+        super(SubnetResourceDriver, self).__init__(provider, credentials)
+        if "profile" in credentials:
+            boto3.setup_default_session(profile_name=credentials["profile"])
+        self.driver = boto3
+        # Should remove this when I actually have a real model for the network.
+        # e.g. model.get("Network", "etc...")
+        self.subnetwork = cloudless.providers.aws.impl.subnetwork.SubnetworkClient(boto3,
+                                                                                   mock=False)
+        self.model = model
+
+    def _get_network(self, network):
+        if "Network" not in self.model.resources():
+            raise DisallowedOperationException(
+                "Network model must be registered to use Subnet model.")
+        networks = self.model.get("Network", network)
+        if len(networks) != 1:
+            raise DisallowedOperationException(
+                "Matcher must match exactly one network, %s matched %s" % (
+                    network, networks))
+        return networks[0]
+
+    def create(self, resource_definition):
+        subnet = resource_definition
+        logger.info("Creating subnet: %s", subnet)
+        network = self._get_network(subnet.network)
+        old_subnetworks = self.subnetwork.create_from_args(network.name, network.id,
+                                                           network.cidr_block, subnet.name, 3,
+                                                           subnet.size)
+        subnets = [{"id": old_subnetwork.subnetwork_id,
+                    "availability_zone": old_subnetwork.availability_zone,
+                    "cidr_block": old_subnetwork.cidr_block}
+                   for old_subnetwork in old_subnetworks]
+        return SubnetModel(version=subnet.version, name=subnet.name, subnets=subnets,)
+
+    def apply(self, resource_definition):
+        subnets = self.get(resource_definition)
+        if len(subnets) != 1:
+            raise DisallowedOperationException(
+                "Cannot apply, matched more than one subnet!: %s" % subnets)
+        logger.info("Applying subnet: %s", subnets[0])
+        return subnets[0]
+
+    def delete(self, resource_definition):
+        subnet = resource_definition
+        logger.info("Deleting subnet: %s", subnet)
+        network = self._get_network(subnet.network)
+        return self.subnetwork.destroy_with_args(network.name, network.id, subnet.name)
+
+    def get(self, resource_definition):
+        subnet = resource_definition
+        network = self._get_network(subnet.network)
+        old_subnetworks = self.subnetwork.get_with_args(network.name, subnet.name)
+        if not old_subnetworks:
+            return []
+        subnets = [{"id": old_subnetwork.subnetwork_id,
+                    "availability_zone": old_subnetwork.availability_zone,
+                    "cidr_block": old_subnetwork.cidr_block}
+                   for old_subnetwork in old_subnetworks]
+        return [SubnetModel(version=subnet.version, name=subnet.name,
+                            subnets=subnets)]
+
+    def flags(self, resource_definition):
+        return []

--- a/cloudless/providers/aws_mock/model.py
+++ b/cloudless/providers/aws_mock/model.py
@@ -3,7 +3,7 @@ Cloudless Model on Mock AWS
 """
 import os
 import cloudless.model
-from cloudless.providers.aws_mock import firewall, network_model, image_model
+from cloudless.providers.aws_mock import firewall, network_model, image_model, subnet_model
 
 def get_model(credentials):
     """
@@ -21,4 +21,7 @@ def get_model(credentials):
     model.register("Image",
                    "%s/image.json" % models_dir,
                    image_model.MockImageResourceDriver("mock_aws", credentials))
+    model.register("Subnet",
+                   "%s/subnet.json" % models_dir,
+                   subnet_model.MockSubnetResourceDriver("mock_aws", credentials, model))
     return model

--- a/cloudless/providers/aws_mock/subnet_model.py
+++ b/cloudless/providers/aws_mock/subnet_model.py
@@ -1,0 +1,36 @@
+"""
+Cloudless Subnet Model on Mock AWS
+"""
+from moto import mock_ec2
+import cloudless.model
+
+@mock_ec2
+class MockSubnetResourceDriver(cloudless.model.ResourceDriver):
+    """
+    This class is what gets called when the user is trying to interact with a "Subnet" resource.
+
+    By the time it gets called to interact with "Subnet" resources, it should be fully initialized
+    and prepared to interact with the backing provider, because that is all configured up front.
+    """
+    def __init__(self, provider, credentials, model):
+        self.provider = provider
+        self.credentials = credentials
+        self.driver = cloudless.providers.aws.subnet_model.SubnetResourceDriver(provider,
+                                                                                credentials,
+                                                                                model)
+        super(MockSubnetResourceDriver, self).__init__(provider, credentials)
+
+    def create(self, resource_definition):
+        return self.driver.create(resource_definition)
+
+    def apply(self, resource_definition):
+        return self.driver.apply(resource_definition)
+
+    def delete(self, resource_definition):
+        return self.driver.delete(resource_definition)
+
+    def get(self, resource_definition):
+        return self.driver.get(resource_definition)
+
+    def flags(self, resource_definition):
+        return self.driver.flags(resource_definition)

--- a/cloudless/types/common.py
+++ b/cloudless/types/common.py
@@ -143,3 +143,16 @@ class ImageModel(Resource):
     id: Optional[str] = None
     creation_date: Optional[str] = None
 ImageModel.schema = load_model("image.json")
+
+@attr.s(auto_attribs=True)
+class SubnetModel(Resource):
+    """
+    Simple container to hold subnet information.
+    """
+    version: str
+    name: str
+    network: Optional[NetworkModel] = None
+    region: Optional[str] = None
+    subnets: Optional[list] = None
+    size: Optional[int] = 256
+SubnetModel.schema = load_model("subnet.json")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ Tests for model management.
 import pytest
 import cloudless
 from cloudless.testutils.blueprint_tester import generate_unique_name
-from cloudless.types.common import Firewall, NetworkModel, ImageModel
+from cloudless.types.common import Firewall, NetworkModel, ImageModel, SubnetModel
 
 def run_firewall_model_test(profile=None, provider=None, credentials=None):
     """
@@ -16,9 +16,10 @@ def run_firewall_model_test(profile=None, provider=None, credentials=None):
     network_name = generate_unique_name("network")
 
     # Create our models
-    network = NetworkModel.fromdict({"name": network_name, "version": "0.0.0"})
+    network_dict = {"name": network_name, "version": "0.0.0"}
+    network = NetworkModel.fromdict(network_dict)
     firewall = Firewall.fromdict({"name": network_name, "version": "0.0.0",
-                                  "network": {"name": network_name}})
+                                  "network": {"name": network.name}})
 
     # Make sure our models are registered
     assert "Firewall" in client.model.resources()
@@ -71,6 +72,54 @@ def run_image_model_test(profile=None, provider=None, credentials=None):
     assert len(image_get) == 1
     assert "ubuntu" in image_get[0].name
 
+def run_subnet_model_test(profile=None, provider=None, credentials=None):
+    """
+    Test model management on the given provider.
+    """
+    client = cloudless.Client(profile, provider, credentials)
+
+    # Get a unique "namespace" for testing
+    network_name = generate_unique_name("network")
+
+    # Create our models
+    network_dict = {"name": network_name, "version": "0.0.0"}
+    network = NetworkModel.fromdict(network_dict)
+    subnet = SubnetModel.fromdict({"name": network_name, "version": "0.0.0",
+                                   "network": network_dict, "size": 256})
+
+    # Make sure our models are registered
+    assert "Subnet" in client.model.resources()
+    assert "Network" in client.model.resources()
+
+    # Create a network and do some sanity checks
+    network_create = client.model.create("Network", network)
+
+    network_get = client.model.get("Network", network)
+    assert len(network_get) == 1
+    assert network_get[0] == network_create
+    assert network_get[0].name == network.name
+
+    # Create an subnet and do some sanity checks
+    subnet_create = client.model.create("Subnet", subnet)
+
+    subnet_get = client.model.get("Subnet", subnet)
+    assert len(subnet_get) == 1
+    assert subnet_get[0] == subnet_create
+    assert subnet_get[0].name == subnet.name
+
+    # Delete the subnet
+    subnet_delete = client.model.delete("Subnet", subnet)
+    assert not subnet_delete
+
+    subnet_get = client.model.get("Subnet", subnet)
+    assert not subnet_get
+
+    # Delete the network
+    network_delete = client.model.delete("Network", network)
+    assert not network_delete
+
+    network_get = client.model.get("Network", network)
+    assert not network_get
 
 @pytest.mark.mock_aws
 def test_firewall_model_mock():
@@ -86,6 +135,12 @@ def test_image_model_mock():
     """
     run_image_model_test(provider="mock-aws", credentials={})
 
+@pytest.mark.mock_aws
+def test_subnet_model_mock():
+    """
+    Run tests using the mock aws driver (moto).
+    """
+    run_subnet_model_test(provider="mock-aws", credentials={})
 
 # Disabling anything besides mock AWS as this API is still in flux
 #@pytest.mark.aws


### PR DESCRIPTION
This is also necessary for instances.  There are some considerations
here specifically for AWS.  We actually provide the abstraction of one
"Subnet" per name, region combination which means that the AWS backend
automatically "stripes" the subnets across multiple AZs (something
google won't have to do because subnets are natively region wide which
makes more sense).