### PR TITLE
Support relative file paths in models

### DIFF
--- a/cloudless/model/__init__.py
+++ b/cloudless/model/__init__.py
@@ -21,7 +21,10 @@ class Resource:
     @classmethod
     def fromdict(cls, resource_dict):
         """Create a new instance of this resource from a dictionary representation."""
-        # This is a gross hack to get this working for now...
+        # This is a gross hack to get this working for now...  I want each instance of a Resource
+        # object to include a "schema" member, and so I attach it to the class and reference it
+        # here.  I could probably just have the init do it, but then the subclasses have to remember
+        # to call super.
         # pylint: disable=no-member
         validate(instance=resource_dict, schema=cls.schema)
         return cattr.structure(resource_dict, cls)

--- a/cloudless/types/common.py
+++ b/cloudless/types/common.py
@@ -17,8 +17,8 @@ what Network it's in and encapsulates all information about it.  Additional func
 extract instances or subnetworks could be layered on top of this.
 """
 import os
-import json
 from typing import Optional
+import jsonref
 import attr
 from cloudless.model import Resource
 
@@ -99,10 +99,11 @@ def load_model(model_filename):
 
     I might just have to not use attrs to do this.  :(
     """
-    schema_path = "%s/../cloudless-core-model/models/%s" % (os.path.dirname(
-        os.path.realpath(__file__)), model_filename)
+    schema_path = os.path.abspath("%s/../cloudless-core-model/models/%s" % (os.path.dirname(
+        os.path.realpath(__file__)), model_filename))
+    schema_uri = 'file://{}/'.format(os.path.dirname(schema_path))
     with open(schema_path) as model_raw:
-        model = json.loads(model_raw.read())
+        model = jsonref.loads(model_raw.read(), base_uri=schema_uri, jsonschema=True)
     return model
 
 @attr.s(auto_attribs=True)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ REQUIRED = [
     'apache-libcloud>=2.3.0,<2.4.0',
     'pycryptodome>=3.6.6,<3.7.0',
     "jsonschema>=3.0.1,<4.0.0",
+    "jsonref>=0.2,<1.0",
     "cattrs>=0.9.0,<1.0.0",
     # Even though moto is for testing, need it for the "mock-aws" provider.
     'moto>=1.3.7,<1.4.0',


### PR DESCRIPTION
This is important because some models have selectors that select other
resource types.  For example a subnet has a selector for a network, and
we want that schema to actually match exactly the way you'd select for a
network on its own.